### PR TITLE
名前を付けて保存/リネームで、古いプロファイル名をコンボボックスに入れるようにした w/nits

### DIFF
--- a/am/win32util.h
+++ b/am/win32util.h
@@ -6,6 +6,12 @@ namespace AM::Win32 {
 
 using tstring = std::basic_string<TCHAR>;
 
+inline tstring remove_ws_on_both_ends(const tstring &src) {
+  auto b = std::find_if(src.begin(), src.end(), [](WCHAR c) { return !_istspace(c); });
+  auto e = std::find_if(src.rbegin(), src.rend(), [](WCHAR c) { return !_istspace(c); }).base();
+  return b < e ? tstring{b, e} : tstring{};
+}
+
 //
 // get null-terminated string from Win32 API and return it as tstring
 //


### PR DESCRIPTION
- 名前を付けて保存/リネームで、古いプロファイル名をコンボボックスに入れるようにした
- プロファイル名の両端の空白を取り除くようにした